### PR TITLE
Set an explicit width and height on image 

### DIFF
--- a/weather/css/small.css
+++ b/weather/css/small.css
@@ -37,6 +37,8 @@ header {
 
 img {
   max-width: 100%;
+  width: 285px;
+  height: 286px;
 }
 
 h1 {


### PR DESCRIPTION
Set an explicit width and height on image elements to reduce layout shifts and improve CLS